### PR TITLE
Make Org property used for :auto-group selector customizable

### DIFF
--- a/examples.org
+++ b/examples.org
@@ -55,11 +55,7 @@ And you'd get an agenda looking like this:
 
 [[screenshots/auto-group.png]]
 
-The property name can be customized. This becomes handy if you already
-have, for instance, an Org property named =ProjectId= attached to your
-items. Instead of duplicating this Org property and renaming it to
-=agenda-group=, you can set =org-super-agenda-group-property-name= to
-an appropriate value:
+The property name can be customized. This becomes handy if you already have, for instance, an Org property named =ProjectId= attached to your items. Instead of duplicating this Org property and renaming it to =agenda-group=, you can set =org-super-agenda-group-property-name= to an appropriate value:
 
 #+BEGIN_SRC elisp :results none
   (let ((org-super-agenda-group-property-name "ProjectId")
@@ -68,8 +64,7 @@ an appropriate value:
     (org-agenda-list))
 #+END_SRC
 
-This causes the =:auto-group= selector to sort your agenda items into
-groups that reflect your =ProjectIds=.
+This causes the =:auto-group= selector to sort your agenda items into groups that reflect your =ProjectIds=.
 
 ** Automatically by category
 

--- a/examples.org
+++ b/examples.org
@@ -55,6 +55,22 @@ And you'd get an agenda looking like this:
 
 [[screenshots/auto-group.png]]
 
+The property name can be customized. This becomes handy if you already
+have, for instance, an Org property named =ProjectId= attached to your
+items. Instead of duplicating this Org property and renaming it to
+=agenda-group=, you can set =org-super-agenda-group-property-name= to
+an appropriate value:
+
+#+BEGIN_SRC elisp :results none
+  (let ((org-super-agenda-group-property-name "ProjectId")
+        (org-super-agenda-groups
+         '((:auto-group t))))
+    (org-agenda-list))
+#+END_SRC
+
+This causes the =:auto-group= selector to sort your agenda items into
+groups that reflect your =ProjectIds=.
+
 ** Automatically by category
 
 In the same way, items can automatically be grouped by their category (which is usually the filename of the buffer they're in).

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -139,7 +139,7 @@ See readme for information."
   :type 'list)
 
 (defcustom org-super-agenda-group-property-name "agenda-group"
-  "The name of the Org property used by the :auto-group selector to figure out the agenda group name an item is sorted into."
+  "Name of the Org property used by the :auto-group selector."
   :type 'string)
 
 (defcustom org-super-agenda-properties-inherit t

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -662,7 +662,7 @@ The string should be the priority cookie letter, e.g. \"A\".")
   (cl-loop with groups = (ht-create)
            for item in all-items
            for group = (org-entry-get (org-super-agenda--get-marker item)
-				      org-super-agenda-group-property-name
+                                      org-super-agenda-group-property-name
                                       org-super-agenda-properties-inherit)
            if group
            do (ht-set! groups group (cons item (ht-get groups group)))

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -138,6 +138,10 @@ Populated automatically by `org-super-agenda--defgroup'.")
 See readme for information."
   :type 'list)
 
+(defcustom org-super-agenda-group-property-name "agenda-group"
+  "The name of the Org property used by the :auto-group selector to figure out the agenda group name an item is sorted into."
+  :type 'string)
+
 (defcustom org-super-agenda-properties-inherit t
   "Use property inheritance when checking properties with the :auto-group selector.
 With this enabled, you can set the \"agenda-group\" property for
@@ -658,7 +662,7 @@ The string should be the priority cookie letter, e.g. \"A\".")
   (cl-loop with groups = (ht-create)
            for item in all-items
            for group = (org-entry-get (org-super-agenda--get-marker item)
-                                      "agenda-group"
+				      org-super-agenda-group-property-name
                                       org-super-agenda-properties-inherit)
            if group
            do (ht-set! groups group (cons item (ht-get groups group)))


### PR DESCRIPTION
This allows for using the :auto-group selector with already existing
Org properties.

* org-super-agenda.el Introduce org-super-agenda-group-property-name
  and use it instead of the hard-coded 'agenda-group' property name.
* examples.org Extend the :auto-group selector example to show the
  new feature.