### PR TITLE
This PR adds a face for org-super-agenda groups header.

### DIFF
--- a/README.org
+++ b/README.org
@@ -214,6 +214,7 @@ These selectors take one argument alone, or multiple arguments in a list.
 +  Keyword ~:face~, used to apply faces to items in groups.
 +  Keyword ~:transformer~, used to transform items in groups.
 +  Option ~org-super-agenda-header-separator~, which can, e.g. be set to an empty string for a more compact view.  (Thanks to [[https://github.com/sdelafond][Sébastien Delafond]].)
++  Face ~org-super-agenda-header~, which can be used to customize group headers.  (Thanks to [[https://github.com/cslux][Christian Schwarzgruber]].)
 
 ** 1.0.1
 

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -174,6 +174,11 @@ making it stretch across the screen."
   "String inserted before group headers."
   :type 'string)
 
+;;;; Faces
+
+(defface org-super-agenda-header '((t (:inherit org-agenda-structure)))
+  "Face used in agenda for `org-super-agenda' group name header.")
+
 ;;;; Macros
 
 (defmacro org-super-agenda--when-with-marker-buffer (form &rest body)
@@ -230,7 +235,7 @@ Prepended with `org-super-agenda-header-separator'."
   (pcase s
     ('none "")
     (_ (setq s (concat " " s))
-       (org-add-props s nil 'face 'org-agenda-structure
+       (org-add-props s nil 'face 'org-super-agenda-header
                       'keymap org-super-agenda-header-map
                       ;; NOTE: According to the manual, only `keymap' should be necessary, but in my
                       ;; testing, it only takes effect in Agenda buffers when `local-map' is set, so

--- a/org-super-agenda.info
+++ b/org-super-agenda.info
@@ -465,6 +465,9 @@ File: README.info,  Node: 11-pre,  Next: 101,  Up: Changelog
    • Option ‘org-super-agenda-header-separator’, which can, e.g.  be set
      to an empty string for a more compact view.  (Thanks to Sébastien
      Delafond (https://github.com/sdelafond).)
+   • Face ‘org-super-agenda-header’, which can be used to customize
+     group headers.  (Thanks to Christian Schwarzgruber
+     (https://github.com/cslux).)
 
 
 File: README.info,  Node: 101,  Next: 100,  Prev: 11-pre,  Up: Changelog
@@ -548,11 +551,11 @@ Node: Normal selectors11398
 Node: Tips15747
 Node: Changelog16598
 Node: 11-pre16766
-Node: 10117204
-Node: 10017545
-Node: Development17650
-Node: Bugs18042
-Node: Credits18681
+Node: 10117368
+Node: 10017709
+Node: Development17814
+Node: Bugs18206
+Node: Credits18845
 
 End Tag Table
 


### PR DESCRIPTION
Under some circumstances it is desired to use a different face for
`org-super-agenda` groups headers.


Maybe it is better to inherit from org-agenda-structure?

regards,
Christian