### PR TITLE
Change: org-super-agenda-header-separator can be a character now

### DIFF
--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -180,8 +180,10 @@ making it stretch across the screen."
   :type 'boolean)
 
 (defcustom org-super-agenda-header-separator "\n"
-  "String inserted before group headers."
-  :type 'string)
+  "Separator inserted before group headers.
+If a string, a newline is added.  If a character, it is repeated
+to fill window width."
+  :type '(choice character string))
 
 ;;;; Faces
 
@@ -240,7 +242,7 @@ If ANY is non-nil, return as soon as FORM returns non-nil."
 
 (defun org-super-agenda--make-agenda-header (s)
   "Return agenda header containing string S.
-Prepended with `org-super-agenda-header-separator'."
+Prepended with `org-super-agenda-header-separator', which see."
   (pcase s
     ('none "")
     (_ (setq s (concat " " s))
@@ -250,7 +252,11 @@ Prepended with `org-super-agenda-header-separator'."
                       ;; testing, it only takes effect in Agenda buffers when `local-map' is set, so
                       ;; we'll use both.
                       'local-map org-super-agenda-header-map)
-       (concat org-super-agenda-header-separator s))))
+       (concat
+        (cl-typecase org-super-agenda-header-separator
+          (character (concat (make-string (window-width) org-super-agenda-header-separator) "\n"))
+          (string org-super-agenda-header-separator))
+        s))))
 
 (defsubst org-super-agenda--get-priority-cookie (s)
   "Return priority character for string S.


### PR DESCRIPTION
After this commit the variable `org-super-agenda-header-separator` can be either a character or a string.

If it is a character, it will be expanded to window width, with a newline appended.

This is for making the separator behaves like `org-agenda-block-separator`.
The only difference is there is no newline added if `org-super-agenda-header-separator` is a string.