### PR TITLE
Hide group header and header separator if no tasks are left after fitering

### DIFF
--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -337,13 +337,14 @@ With prefix argument ARG, turn on if positive, otherwise off."
                                      (advice-add to :after fn))
                                  (lambda (from fn)
                                    ;; Disable mode
-                                   (advice-remove from fn)))))
+                                   (advice-remove from fn))))
+        (hook-function (if org-super-agenda-mode #'add-hook #'remove-hook)))
     (funcall advice-function-filter-return #'org-agenda-finalize-entries
              #'org-super-agenda--filter-finalize-entries)
     (funcall advice-function-after #'org-agenda-filter-apply
              #'org-super-agenda--hide-or-show-groups)
-    (funcall advice-function-after #'org-agenda-finalize
-             #'org-super-agenda--hide-or-show-groups)
+    (funcall hook-function 'org-agenda-finalize-hook
+             'org-super-agenda--hide-or-show-groups)
 
     ;; Add variable to list of variables (see issue #22).
     (if org-super-agenda-mode

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -215,6 +215,10 @@ See `format-time-string'."
   "Text properties added to group headers."
   :type 'plist)
 
+(defcustom org-super-agenda-hide-empty-group-headers nil
+  "If non-nil, hide group header when it has no items."
+  :type 'boolean)
+
 ;;;; Faces
 
 (defface org-super-agenda-header '((t (:inherit org-agenda-structure)))
@@ -341,10 +345,11 @@ With prefix argument ARG, turn on if positive, otherwise off."
         (hook-function (if org-super-agenda-mode #'add-hook #'remove-hook)))
     (funcall advice-function-filter-return #'org-agenda-finalize-entries
              #'org-super-agenda--filter-finalize-entries)
-    (funcall advice-function-after #'org-agenda-filter-apply
-             #'org-super-agenda--hide-or-show-groups)
-    (funcall hook-function 'org-agenda-finalize-hook
-             'org-super-agenda--hide-or-show-groups)
+    (when org-super-agenda-hide-empty-group-headers
+      (funcall advice-function-after #'org-agenda-filter-apply
+               #'org-super-agenda--hide-or-show-groups)
+      (funcall hook-function 'org-agenda-finalize-hook
+               'org-super-agenda--hide-or-show-groups))
 
     ;; Add variable to list of variables (see issue #22).
     (if org-super-agenda-mode

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -1172,7 +1172,7 @@ STRING should be that returned by `org-agenda-finalize-entries'"
                                    (org-get-at-bol 'org-super-agenda-header))))
               (group-item-visible-p () (and (org-get-at-bol 'type) (not (org-get-at-bol 'invisible))))
               (next-header () (let (header nohide grid-end)
-                                (while (and (not (bobp)) (not header))
+                                (while (not (or (bobp) header))
                                   (cond
                                     ((header-p)
                                      (setq header (cons (1- (or (previous-single-property-change (point-at-eol) 'org-super-agenda-header) (1+ (point-min))))

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -1184,23 +1184,22 @@ STRING should be that returned by `org-agenda-finalize-entries'"
                                   (beginning-of-line 0))
                                 header))
               (hide-or-show-header (header)
-                (cl-loop
-                   with start = (car header)
-                   with end = (cadr header)
-                   with nohide = (cddr header)
-                   with props = `(invisible org-filtered org-filter-type org-super-agenda-header)
-                   when header
-                   initially
-                   do (goto-char end)
-                   while (> (point) start)
-                   do
-                     (when (or (grid-p) (header-p))
-                       (let ((beg (1- (point-at-bol)))
-                             (end (point-at-eol)))
-                         (if nohide
-                             (remove-text-properties beg end props)
-                           (add-text-properties beg end props))))
-                     (beginning-of-line 0))))
+                (when header
+                  (cl-loop
+                     with start = (car header)
+                     with end = (cadr header)
+                     with nohide = (cddr header)
+                     with props = `(invisible org-filtered org-filter-type org-super-agenda-header)
+                     initially do (goto-char end)
+                     while (and start (> (point) start))
+                     do
+                       (when (or (grid-p) (header-p))
+                         (let ((beg (1- (point-at-bol)))
+                               (end (point-at-eol)))
+                           (if nohide
+                               (remove-text-properties beg end props)
+                             (add-text-properties beg end props))))
+                       (beginning-of-line 0)))))
     (let ((inhibit-read-only t))
       (save-excursion
         (goto-char (point-max))

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -1175,8 +1175,9 @@ STRING should be that returned by `org-agenda-finalize-entries'"
                                 (while (not (or (bobp) header))
                                   (cond
                                     ((header-p)
-                                     (setq header (cons (1- (or (previous-single-property-change (point-at-eol) 'org-super-agenda-header) (1+ (point-min))))
-                                                        (cons (or grid-end (point-at-eol)) nohide))))
+                                     (setq header (list (1- (or (previous-single-property-change (point-at-eol) 'org-super-agenda-header) (1+ (point-min))))
+                                                        (or grid-end (point-at-eol))
+                                                        nohide)))
                                     ((group-item-visible-p)
                                      (setq nohide t))
                                     ((and (grid-p) (not grid-end))
@@ -1186,9 +1187,9 @@ STRING should be that returned by `org-agenda-finalize-entries'"
               (hide-or-show-header (header)
                 (when header
                   (cl-loop
-                     with start = (car header)
-                     with end = (cadr header)
-                     with nohide = (cddr header)
+                     with start = (nth 0 header)
+                     with end = (nth 1 header)
+                     with nohide = (nth 2 header)
                      with props = `(invisible org-filtered org-filter-type org-super-agenda-header)
                      initially do (goto-char end)
                      while (and start (> (point) start))

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -1187,7 +1187,7 @@ STRING should be that returned by `org-agenda-finalize-entries'"
                 (when header
                   (cl-loop
                      with (start end hide-p) = header
-                     with props = `(invisible org-filtered org-filter-type org-super-agenda)
+                     with props = `(invisible org-filtered org-filter-type org-super-agenda-filtered)
                      initially do (goto-char end)
                      while (and start (> (point) start))
                      do (when (or (grid-p) (header-p))

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -1165,46 +1165,49 @@ STRING should be that returned by `org-agenda-finalize-entries'"
 (defun org-super-agenda--hide-or-show-groups (&rest _)
   "Hide/Show any empty/non-empty groups after `org-agenda-filter-apply',
 `org-agenda-remove-filter' or `org-agenda-redo' was called."
-  (let ((inhibit-read-only t) start end nohide)
-    (save-excursion
-      (goto-char (point-min))
-      (cl-loop until (and (eobp)
-                          ;; Maybe a group at the end needs to be hidden, so iterate one more time if end is `non-nil'
-                          (not end))
-               do
-               (cond
-                 ((or (org-get-at-bol 'org-super-agenda-header) (eobp))
+  (cl-flet ((header-p () (or (org-get-at-bol 'org-super-agenda-header) (eobp)))
+            (hide-or-show-header (start end nohide)
+              (when (and start end)
+                (save-excursion
+                  (cl-loop with until = (point)
+                     with beg = nil
+                     with end = nil
+                     with props = `(invisible org-filtered org-filter-type org-super-agenda-header)
+                     initially do (goto-char start)
+                     while (< (point) until)
+                     do
+                       (beginning-of-line 2)
+                       (unless (or (org-get-at-bol 'org-agenda-structural-header)
+                                   (org-get-at-bol 'org-agenda-date-header)
+                                   (org-get-at-bol 'type))
+                         (setq beg (1- (point-at-bol))
+                               end (point-at-eol))
+                         (if nohide
+                             (remove-text-properties beg end props)
+                           (add-text-properties beg end props)))))))
+            (group-item-visible-p () (and (org-get-at-bol 'type) (not (org-get-at-bol 'invisible)))))
+    (let ((inhibit-read-only t) start end nohide)
+      (save-excursion
+        (goto-char (point-min))
+        (while (not (eobp))
+          (cond
+            ((header-p)
+             (hide-or-show-header start end nohide)
 
-                  (when (and start end)
-                    (save-excursion
-                      (cl-loop with until = (point)
-                               with beg = nil
-                               with end = nil
-                               with props = `(invisible org-filtered org-filter-type org-super-agenda-header)
-                               initially do (goto-char start)
-                               while (< (point) until)
-                               do
-                               (beginning-of-line 2)
-                               (unless (or (org-get-at-bol 'org-agenda-structural-header)
-                                           (org-get-at-bol 'org-agenda-date-header)
-                                           (org-get-at-bol 'type))
-                                 (setq beg (1- (point-at-bol))
-                                       end (point-at-eol))
-                                   (if nohide
-                                       (remove-text-properties beg end props)
-                                     (add-text-properties beg end props)))
-                               finally (setq nohide nil))))
+             ;; Start/End of the header.
+             (setq nohide nil ;; reset
+                   start (1- (point))
+                   end (next-single-property-change (point) 'org-super-agenda-header))
 
-                  (setq start (1- (point)) ;; Always one less than point.
-                        end (next-single-property-change (point) 'org-super-agenda-header))
+             ;; When `end' is `nil' we are at the end of the buffer.
+             (when end (goto-char end)))
 
-                  ;; When `end' is `nil', we are very likly at the end of the buffer.
-                  (when end (goto-char end)))
-
-                 ((and (org-get-at-bol 'type) (not (org-get-at-bol 'invisible)))
-                  ;; There was at least one task of the group visible.
-                  (setq nohide t)))
-               (beginning-of-line 2)))))
+            ((group-item-visible-p)
+             ;; There was at least one task of the group visible.
+             (setq nohide t)))
+          (beginning-of-line 2))
+        ;; Maybe there is a group at the end of the buffer which needs to be hidden/shown
+        (hide-or-show-header start end nohide)))))
 
 ;;;; Footer
 

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -1187,7 +1187,7 @@ STRING should be that returned by `org-agenda-finalize-entries'"
                 (when header
                   (cl-loop
                      with (start end hide-p) = header
-                     with props = `(invisible org-filtered org-filter-type org-super-agenda-header)
+                     with props = `(invisible org-filtered org-filter-type org-super-agenda)
                      initially do (goto-char end)
                      while (and start (> (point) start))
                      do (when (or (grid-p) (header-p))

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -299,7 +299,10 @@ face `org-super-agenda-header' appended, and the text properties
            ;; NOTE: According to the manual, only `keymap' should be necessary, but in my
            ;; testing, it only takes effect in Agenda buffers when `local-map' is set, so
            ;; we'll use both.
-           'local-map org-super-agenda-header-map)
+           'local-map org-super-agenda-header-map
+           'org-super-agenda-header t)
+         (org-add-props org-super-agenda-header-separator nil
+           'org-super-agenda-header t)
          ;; Don't apply faces and properties to the separator part of the string.
          (concat separator s)))))
 
@@ -324,15 +327,27 @@ marker."
   "Global minor mode to group items in Org agenda views according to `org-super-agenda-groups'.
 With prefix argument ARG, turn on if positive, otherwise off."
   :global t
-  (let ((advice-function (if org-super-agenda-mode
-                             (lambda (to fn)
-                               ;; Enable mode
-                               (advice-add to :filter-return fn))
-                           (lambda (from fn)
-                             ;; Disable mode
-                             (advice-remove from fn)))))
-    (funcall advice-function #'org-agenda-finalize-entries
+  (let ((advice-function-filter-return (if org-super-agenda-mode
+                                           (lambda (to fn)
+                                             ;; Enable mode
+                                             (advice-add to :filter-return fn))
+                                         (lambda (from fn)
+                                           ;; Disable mode
+                                           (advice-remove from fn))))
+        (advice-function-after (if org-super-agenda-mode
+                                   (lambda (to fn)
+                                     ;; Enable mode
+                                     (advice-add to :after fn))
+                                 (lambda (from fn)
+                                   ;; Disable mode
+                                   (advice-remove from fn)))))
+    (funcall advice-function-filter-return #'org-agenda-finalize-entries
              #'org-super-agenda--filter-finalize-entries)
+    (funcall advice-function-after #'org-agenda-filter-apply
+             #'org-super-agenda--hide-or-show-groups)
+    (funcall advice-function-after #'org-agenda-finalize
+             #'org-super-agenda--hide-or-show-groups)
+
     ;; Add variable to list of variables (see issue #22).
     (if org-super-agenda-mode
         (add-to-list 'org-agenda-local-vars 'org-super-agenda-groups)
@@ -1145,6 +1160,51 @@ STRING should be that returned by `org-agenda-finalize-entries'"
        org-super-agenda--group-items
        (-remove #'s-blank-str? it)
        (s-join "\n" it)))
+
+;;;; Hide/Show filter
+(defun org-super-agenda--hide-or-show-groups (&rest _)
+  "Hide/Show any empty/non-empty groups after `org-agenda-filter-apply',
+`org-agenda-remove-filter' or `org-agenda-redo' was called."
+  (let ((inhibit-read-only t) start end nohide)
+    (save-excursion
+      (goto-char (point-min))
+      (cl-loop until (and (eobp)
+                          ;; Maybe a group at the end needs to be hidden, so iterate one more time if end is `non-nil'
+                          (not end))
+               do
+               (cond
+                 ((or (org-get-at-bol 'org-super-agenda-header) (eobp))
+
+                  (when (and start end)
+                    (save-excursion
+                      (cl-loop with until = (point)
+                               with beg = nil
+                               with end = nil
+                               with props = `(invisible org-filtered org-filter-type org-super-agenda-header)
+                               initially do (goto-char start)
+                               while (< (point) until)
+                               do
+                               (beginning-of-line 2)
+                               (unless (or (org-get-at-bol 'org-agenda-structural-header)
+                                           (org-get-at-bol 'org-agenda-date-header)
+                                           (org-get-at-bol 'type))
+                                 (setq beg (1- (point-at-bol))
+                                       end (point-at-eol))
+                                   (if nohide
+                                       (remove-text-properties beg end props)
+                                     (add-text-properties beg end props)))
+                               finally (setq nohide nil))))
+
+                  (setq start (1- (point)) ;; Always one less than point.
+                        end (next-single-property-change (point) 'org-super-agenda-header))
+
+                  ;; When `end' is `nil', we are very likly at the end of the buffer.
+                  (when end (goto-char end)))
+
+                 ((and (org-get-at-bol 'type) (not (org-get-at-bol 'invisible)))
+                  ;; There was at least one task of the group visible.
+                  (setq nohide t)))
+               (beginning-of-line 2)))))
 
 ;;;; Footer
 

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -1161,8 +1161,8 @@ STRING should be that returned by `org-agenda-finalize-entries'"
 
 ;;;; Hide/Show filter
 (defun org-super-agenda--hide-or-show-groups (&rest _)
-  "Hide/Show any empty/non-empty groups after `org-agenda-finalize',
-`org-agenda-filter-apply'  was called."
+  "Hide/Show any empty/non-empty groups.
+This is happens after `org-agenda-finalize' or `org-agenda-filter-apply' was called."
   (cl-labels ((header-p () (org-get-at-bol 'org-super-agenda-header))
               (grid-p () (not (let ((props (text-properties-at (point-at-bol))))
                                 (or (member 'org-agenda-structural-header props)
@@ -1196,7 +1196,7 @@ STRING should be that returned by `org-agenda-finalize-entries'"
                             (if hide-p
                                 (add-text-properties beg end props)
                               (remove-text-properties beg end props))))
-                        (beginning-of-line 0)))))
+                       (beginning-of-line 0)))))
     (let ((inhibit-read-only t))
       (save-excursion
         (goto-char (point-max))


### PR DESCRIPTION
This fixes my reported issue #56. #61 is very likely to be solved with this as well.