### PR TITLE
Added variable with extra header properties

### DIFF
--- a/README.org
+++ b/README.org
@@ -229,6 +229,7 @@ These selectors take one argument alone, or multiple arguments in a list.
 +  Option ~org-super-agenda-date-format~, used to format date headers in the ~:auto-date~ selector.
 +  To-do keyword faces are applied to keywords in group headers.
 +  Option =org-super-agenda-header-separator= may also be a character, which is automatically repeated to the window width.  (Thanks to [[https://github.com/sheepduke][YUE Daian]].)
++  Option =org-super-agenda-header-properties=.  It sets =org-agenda-structural-header= by default, which enables navigating to headers with the default =M-{= / =M-}= bindings in agenda buffers.  (Thanks to [[https://github.com/haji-ali][Abdul-Lateef Haji-Ali]].)
 
 *Changed*
 +  Group headers face is now appended to face list instead of overriding it.

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -193,6 +193,12 @@ to fill window width, and a newline is added."
 See `format-time-string'."
   :type 'string)
 
+(defcustom org-super-agenda-header-properties
+  '(face org-super-agenda-header
+         org-agenda-structural-header t)
+  "Text properties added to group headers."
+  :type 'plist)
+
 ;;;; Faces
 
 (defface org-super-agenda-header '((t (:inherit org-agenda-structure)))
@@ -272,7 +278,7 @@ face `org-super-agenda-header' appended, and the text properties
                           (string org-super-agenda-header-separator))))
          (setq s (concat " " s))
          (add-face-text-property 0 (length s) 'org-super-agenda-header t s)
-         (org-add-props s nil
+         (org-add-props s org-super-agenda-header-properties
            'keymap org-super-agenda-header-map
            ;; NOTE: According to the manual, only `keymap' should be necessary, but in my
            ;; testing, it only takes effect in Agenda buffers when `local-map' is set, so

--- a/org-super-agenda.info
+++ b/org-super-agenda.info
@@ -521,6 +521,10 @@ File: README.info,  Node: 12-pre,  Next: 111,  Up: Changelog
    • Option org-super-agenda-header-separator may also be a character,
      which is automatically repeated to the window width.  (Thanks to
      YUE Daian (https://github.com/sheepduke).)
+   • Option org-super-agenda-header-properties.  It sets
+     org-agenda-structural-header by default, which enables navigating
+     to headers with the default M-{ / M-} bindings in agenda buffers.
+     (Thanks to Abdul-Lateef Haji-Ali (https://github.com/haji-ali).)
 
    *Changed*
    • Group headers face is now appended to face list instead of
@@ -702,16 +706,16 @@ Node: Normal selectors12933
 Node: Tips17564
 Node: Changelog18415
 Node: 12-pre18640
-Node: 11120349
-Node: 1120522
-Node: 10322094
-Node: 10222305
-Node: 10122439
-Node: 10022777
-Node: Development22882
-Node: Bugs23284
-Node: Tests23937
-Node: Credits24256
+Node: 11120620
+Node: 1120793
+Node: 10322365
+Node: 10222576
+Node: 10122710
+Node: 10023048
+Node: Development23153
+Node: Bugs23555
+Node: Tests24208
+Node: Credits24527
 
 End Tag Table
 


### PR DESCRIPTION
Added a variable org-super-agenda-header-props that contains properties to be added to `org-super-agenda` headers. By default it contains the face property and org-agenda-structural-header t, making it possible to navigate the org-super-agenda sections using `M+{` and `M+}` (`org-agenda-forward-block` and `org-agenda-backward-block`) in org-agenda.

This resolves #78 (corrects #81 and re-bases #83 using a separate branch).