### PR TITLE
New selector :property, for matching in the property drawer.

### DIFF
--- a/README.org
+++ b/README.org
@@ -203,7 +203,7 @@ These selectors take one argument alone, or multiple arguments in a list.
 +  =:priority>== :: Group items that are higher than or equal to the given priority, e.g. ~B~.
 +  =:priority<= :: Group items that are lower than the given priority, e.g. ~A~.
 +  =:priority<== :: Group items that are lower than or equal to the given priority, e.g. ~B~.
-+  =:property= :: Group items that match the given property key value.  Argument must be a cons cell of strings, e.g. ( "status" . "To Do" ).
++  =:property= :: Group items that match the given property key value.  Argument must be a cons cell of strings, e.g. ~( "status" . "To Do" )~.
 +  =:regexp= :: Group items that match any of the given regular expressions.
 +  =:scheduled= :: Group items that are scheduled.  Argument can be ~t~ (to match items scheduled for any date), ~nil~ (to match items that are not schedule), ~past~ (to match items scheduled for the past), ~today~ (to match items scheduled for today), or ~future~ (to match items scheduled for the future).  Argument may also be given like ~before DATE~ or ~after DATE~ where DATE is a date string that ~org-time-string-to-absolute~ can process.
 +  =:tag= :: Group items that match any of the given tags.  Argument may be a string or list of strings.

--- a/README.org
+++ b/README.org
@@ -203,6 +203,7 @@ These selectors take one argument alone, or multiple arguments in a list.
 +  =:priority>== :: Group items that are higher than or equal to the given priority, e.g. ~B~.
 +  =:priority<= :: Group items that are lower than the given priority, e.g. ~A~.
 +  =:priority<== :: Group items that are lower than or equal to the given priority, e.g. ~B~.
++  =:property= :: Group items that match the given property key value.  Argument must be a cons cell of strings, e.g. ( "status" . "To Do" ).
 +  =:regexp= :: Group items that match any of the given regular expressions.
 +  =:scheduled= :: Group items that are scheduled.  Argument can be ~t~ (to match items scheduled for any date), ~nil~ (to match items that are not schedule), ~past~ (to match items scheduled for the past), ~today~ (to match items scheduled for today), or ~future~ (to match items scheduled for the future).  Argument may also be given like ~before DATE~ or ~after DATE~ where DATE is a date string that ~org-time-string-to-absolute~ can process.
 +  =:tag= :: Group items that match any of the given tags.  Argument may be a string or list of strings.

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -647,6 +647,15 @@ available."
           (_ (cl-loop for fn in args
                       thereis (funcall fn item)))))
 
+(org-super-agenda--defgroup property
+  "Group items that contain a property with a given value.
+The argument should be a cons cell of strings, e.g. ( \"status\" . \"To Do\" ). "
+  :section-name (concat "Property: '" (cdr args) "' = '"(car args) "'")
+  :test (string= (cdr args)
+                 (org-entry-get (org-super-agenda--get-marker item)
+                                (car args)
+                                org-super-agenda-properties-inherit)))
+
 (org-super-agenda--defgroup regexp
   "Group items that match any of the given regular expressions.
 Argument may be a string or list of strings, each of which should

--- a/test/results.el
+++ b/test/results.el
@@ -1095,6 +1095,37 @@ Wednesday   5 July 2017
   ambition:   In  77 d.:  TODO Visit Mars                                                     :universe:ambition::space:travel:planet:
   test:       Scheduled:  TODO [#C] Get haircut                                                                       :personal:@town:
   ambition:   TODO Practice leaping tall                     !                                           :universe:ambition::personal:
+" "0af641100cfcc5f64d157b26e26fc5b9" "Day-agenda (W27):
+Wednesday   5 July 2017
+
+ Property: '5' = 'Effort'
+  test:       18:00...... Scheduled:  TODO Order a pizza                                                                 :food:dinner:
+
+ Other items
+  test:        7:02...... Sunrise (12:04 of daylight)
+               8:00...... ----------------
+              10:00...... ----------------
+              12:00...... now - - - - - - - - - - - - - - - - - - - - - - - - -
+              12:00...... ----------------
+              14:00...... ----------------
+              16:00...... ----------------
+              18:00...... ----------------
+  test:       19:07...... Sunset 
+              20:00...... ----------------
+  ambition:   Sched. 1x:  TODO [#A] Skype with president of Antarctica                             :universe:ambition:world::meetings:
+  ambition:   In   2 d.:  TODO [#A] Take over the world                                                     :universe:ambition::world:
+  ambition:   In  10 d.:  TODO [#A] Take over the universe                                                         :universe:ambition:
+  test:       In  27 d.:  TODO [#A] Spaceship lease                                                                  :bills:spaceship:
+  test:       Scheduled:  TODO [#B] Fix flux capacitor                                                  :spaceship:shopping:@computer:
+  test:       Scheduled:  TODO Shop for groceries                                                                :food:shopping:@town:
+  ideas:      Scheduled:  SOMEDAY Rewrite Emacs in Common Lisp                            :Emacs:elisp:computers:software:programming:
+  test:       Deadline:   CHECK /r/emacs                                                                               :website:Emacs:
+  ambition:   In   5 d.:  TODO [#B] Renew membership in supervillain club                                         :universe:ambition::
+  test:       In  16 d.:  TODO [#B] Internet                                                                                   :bills:
+  ambition:   In  53 d.:  WAITING Visit the moon                                                     :universe:ambition::space:travel:
+  ambition:   In  77 d.:  TODO Visit Mars                                                     :universe:ambition::space:travel:planet:
+  test:       Scheduled:  TODO [#C] Get haircut                                                                       :personal:@town:
+  ambition:   TODO Practice leaping tall                     !                                           :universe:ambition::personal:
 " "def625677821c807ab1067145e01eb85" "Day-agenda (W27):
 Wednesday   5 July 2017
 

--- a/test/test.el
+++ b/test/test.el
@@ -533,6 +533,11 @@ buffer and do not save the results."
            :groups '((:pred (lambda (item)
                               (s-contains? "moon" item)))))))
 
+(ert-deftest org-super-agenda--test-:property ()
+  ;; DONE: Works.
+  (should (org-super-agenda--test-run
+           :groups '((:property ("Effort" . "5" ))))))
+
 (ert-deftest org-super-agenda--test-:priority ()
   ;; DONE: Works.
   (should (org-super-agenda--test-run


### PR DESCRIPTION
`:property` groups items that match the given property key value.  Argument must be a cons cell of strings, e.g. ( "status" . "To Do" ).

The rationale behind this selector is that some org documents store important key values in the property drawer. One such example is the org documents produced by [org-jira](https://github.com/ahungry/org-jira), where items look like this:

```
** TODO Get coffee                   :BAT_310:
   :PROPERTIES:
   :assignee:
   :filename: BAT
   :reporter: per.weijnitz
   :type:     Task
   :priority: Medium
   :status:   To Do
   :created:  2019-12-13T09:11:45.868+0100
   :updated:  2019-12-13T09:17:10.700+0100
   :ID:       BAT-310
   :CUSTOM_ID: BAT-310
   :END:
...
```

I could group items using the `auto-property` selector, but auto grouping does not allow for a customised behaviour, such as selecting only some combinations of properties and values, and arranging the groups in a specific order. I could also use `:pred`, but it seems a little bit more convenient to have `:property` supported directly.