### PR TITLE
New selector :property, for matching in the property drawer. Now from a feature branch.

### DIFF
--- a/README.org
+++ b/README.org
@@ -203,7 +203,7 @@ These selectors take one argument alone, or multiple arguments in a list.
 +  =:priority>== :: Group items that are higher than or equal to the given priority, e.g. ~B~.
 +  =:priority<= :: Group items that are lower than the given priority, e.g. ~A~.
 +  =:priority<== :: Group items that are lower than or equal to the given priority, e.g. ~B~.
-+  =:property= :: Group items that match the given property key value.  Argument must be a cons cell of strings, e.g. ( "status" . "To Do" ).
++  =:property= :: Group items that match the given property key value.  Argument must be a cons cell of strings, e.g. ~( "status" . "To Do" )~.
 +  =:regexp= :: Group items that match any of the given regular expressions.
 +  =:scheduled= :: Group items that are scheduled.  Argument can be ~t~ (to match items scheduled for any date), ~nil~ (to match items that are not schedule), ~past~ (to match items scheduled for the past), ~today~ (to match items scheduled for today), or ~future~ (to match items scheduled for the future).  Argument may also be given like ~before DATE~ or ~after DATE~ where DATE is a date string that ~org-time-string-to-absolute~ can process.
 +  =:tag= :: Group items that match any of the given tags.  Argument may be a string or list of strings.

--- a/README.org
+++ b/README.org
@@ -203,6 +203,7 @@ These selectors take one argument alone, or multiple arguments in a list.
 +  =:priority>== :: Group items that are higher than or equal to the given priority, e.g. ~B~.
 +  =:priority<= :: Group items that are lower than the given priority, e.g. ~A~.
 +  =:priority<== :: Group items that are lower than or equal to the given priority, e.g. ~B~.
++  =:property= :: Group items that match the given property key value.  Argument must be a cons cell of strings, e.g. ( "status" . "To Do" ).
 +  =:regexp= :: Group items that match any of the given regular expressions.
 +  =:scheduled= :: Group items that are scheduled.  Argument can be ~t~ (to match items scheduled for any date), ~nil~ (to match items that are not schedule), ~past~ (to match items scheduled for the past), ~today~ (to match items scheduled for today), or ~future~ (to match items scheduled for the future).  Argument may also be given like ~before DATE~ or ~after DATE~ where DATE is a date string that ~org-time-string-to-absolute~ can process.
 +  =:tag= :: Group items that match any of the given tags.  Argument may be a string or list of strings.

--- a/README.org
+++ b/README.org
@@ -203,7 +203,7 @@ These selectors take one argument alone, or multiple arguments in a list.
 +  =:priority>== :: Group items that are higher than or equal to the given priority, e.g. ~B~.
 +  =:priority<= :: Group items that are lower than the given priority, e.g. ~A~.
 +  =:priority<== :: Group items that are lower than or equal to the given priority, e.g. ~B~.
-+  =:property= :: Group items that match the given property key value.  Argument must be a cons cell of strings, e.g. ~( "status" . "To Do" )~.
++  =:property= :: Group items that contain a property with a given value. Argument should be either a string representing a property, or a list with a string representing a property, and an optional second argument being either a string representing a value, or a function which will be passed the found property value, if any. With a string argument, or a list of length 1, any item with the given property will match.
 +  =:regexp= :: Group items that match any of the given regular expressions.
 +  =:scheduled= :: Group items that are scheduled.  Argument can be ~t~ (to match items scheduled for any date), ~nil~ (to match items that are not schedule), ~past~ (to match items scheduled for the past), ~today~ (to match items scheduled for today), or ~future~ (to match items scheduled for the future).  Argument may also be given like ~before DATE~ or ~after DATE~ where DATE is a date string that ~org-time-string-to-absolute~ can process.
 +  =:tag= :: Group items that match any of the given tags.  Argument may be a string or list of strings.

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -649,12 +649,27 @@ available."
 
 (org-super-agenda--defgroup property
   "Group items that contain a property with a given value.
-The argument should be a cons cell of strings, e.g. ( \"status\" . \"To Do\" ). "
-  :section-name (concat "Property: '" (cdr args) "' = '"(car args) "'")
-  :test (string= (cdr args)
-                 (org-entry-get (org-super-agenda--get-marker item)
-                                (car args)
-                                org-super-agenda-properties-inherit)))
+Argument should be a list with a string representing a
+property, and an optional second argument being either a string
+representing a value, or a function which will be passed the
+found property value, if any. Without a second argument, any item
+with the given property will match. "
+  :section-name (concat "Property: '" (car args) "'"
+                        (if (= 2 (length args)) (concat " = '" (prin1-to-string (nth 1 args)) "'" )))
+  :test  (let* ((prop (car-safe args))
+                (restriction (nth 1 args))
+                (found-value (org-entry-get (org-super-agenda--get-marker item)
+                                            prop
+                                            org-super-agenda-properties-inherit)))
+           (pcase restriction
+             ((pred null)
+              found-value)
+             ((pred stringp)
+              (string= restriction found-value))
+             ((pred functionp)
+              (funcall restriction found-value))
+             (_ ;; Oops
+              (user-error "List argument to `:property' must either be of length 1, or have either a string of a function as the second element")))))
 
 (org-super-agenda--defgroup regexp
   "Group items that match any of the given regular expressions.

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -647,6 +647,15 @@ available."
           (_ (cl-loop for fn in args
                       thereis (funcall fn item)))))
 
+(org-super-agenda--defgroup property
+  "Group items that contain a property with a given value.
+The argument should be a cons cell of strings, e.g. ( \"status\" . \"To Do\" ). "
+  :section-name (concat "Property: '" (cdr args) "' = '"(car args) "'")
+  :test (string= (cdr args)
+                 (org-entry-get (org-super-agenda--get-marker item)
+                                (car args)
+                                org-super-agenda-properties-inherit)))
+
 (org-super-agenda--defgroup regexp
   "Group items that match any of the given regular expressions.
 Argument may be a string or list of strings, each of which should

--- a/test/results.el
+++ b/test/results.el
@@ -1095,6 +1095,37 @@ Wednesday   5 July 2017
   ambition:   In  77 d.:  TODO Visit Mars                                                     :universe:ambition::space:travel:planet:
   test:       Scheduled:  TODO [#C] Get haircut                                                                       :personal:@town:
   ambition:   TODO Practice leaping tall                     !                                           :universe:ambition::personal:
+" "0af641100cfcc5f64d157b26e26fc5b9" "Day-agenda (W27):
+Wednesday   5 July 2017
+
+ Property: '5' = 'Effort'
+  test:       18:00...... Scheduled:  TODO Order a pizza                                                                 :food:dinner:
+
+ Other items
+  test:        7:02...... Sunrise (12:04 of daylight)
+               8:00...... ----------------
+              10:00...... ----------------
+              12:00...... now - - - - - - - - - - - - - - - - - - - - - - - - -
+              12:00...... ----------------
+              14:00...... ----------------
+              16:00...... ----------------
+              18:00...... ----------------
+  test:       19:07...... Sunset 
+              20:00...... ----------------
+  ambition:   Sched. 1x:  TODO [#A] Skype with president of Antarctica                             :universe:ambition:world::meetings:
+  ambition:   In   2 d.:  TODO [#A] Take over the world                                                     :universe:ambition::world:
+  ambition:   In  10 d.:  TODO [#A] Take over the universe                                                         :universe:ambition:
+  test:       In  27 d.:  TODO [#A] Spaceship lease                                                                  :bills:spaceship:
+  test:       Scheduled:  TODO [#B] Fix flux capacitor                                                  :spaceship:shopping:@computer:
+  test:       Scheduled:  TODO Shop for groceries                                                                :food:shopping:@town:
+  ideas:      Scheduled:  SOMEDAY Rewrite Emacs in Common Lisp                            :Emacs:elisp:computers:software:programming:
+  test:       Deadline:   CHECK /r/emacs                                                                               :website:Emacs:
+  ambition:   In   5 d.:  TODO [#B] Renew membership in supervillain club                                         :universe:ambition::
+  test:       In  16 d.:  TODO [#B] Internet                                                                                   :bills:
+  ambition:   In  53 d.:  WAITING Visit the moon                                                     :universe:ambition::space:travel:
+  ambition:   In  77 d.:  TODO Visit Mars                                                     :universe:ambition::space:travel:planet:
+  test:       Scheduled:  TODO [#C] Get haircut                                                                       :personal:@town:
+  ambition:   TODO Practice leaping tall                     !                                           :universe:ambition::personal:
 " "def625677821c807ab1067145e01eb85" "Day-agenda (W27):
 Wednesday   5 July 2017
 

--- a/test/results.el
+++ b/test/results.el
@@ -445,7 +445,7 @@ Wednesday   5 July 2017
  Scheduled earlier
   ambition:   Sched. 1x:  TODO [#A] Skype with president of Antarctica                             :universe:ambition:world::meetings:
 " "5db2acc8c5a09927fa8b6246b9480d69" "Headlines with TAGS match: Emacs
-Press ‘C-u r’ to search again
+Press `C-u r' to search again with new search string
 
  SOMEDAY items
   ideas:      SOMEDAY Rewrite Emacs in Common Lisp                                        :Emacs:elisp:computers:software:programming:
@@ -701,8 +701,8 @@ Wednesday   5 July 2017
   test:       Scheduled:  TODO [#C] Get haircut                                                                       :personal:@town:
   ambition:   TODO Practice leaping tall                     !                                           :universe:ambition::personal:
 " "ee86c7d11d20c4894e7956db5efce309" "Global list of TODO items of type: ALL
-Press ‘N r’ (e.g. ‘0 r’) to search again: (0)[ALL] (1)TODO (2)TODAY (3)NEXT (4)STARTED (5)IN-PROGRESS (6)UNDERWAY (7)WAITING
-                      (8)SOMEDAY (9)MAYBE (10)CHECK (11)DONE (12)CANCELED
+Available with `N r': (0)[ALL] (1)TODO (2)TODAY (3)NEXT (4)STARTED (5)IN-PROGRESS (6)UNDERWAY (7)WAITING (8)SOMEDAY (9)MAYBE (10)CHECK
+                      (11)DONE (12)CANCELED
 
  Items without deadlines
   ambition:   TODO [#A] Skype with president of Antarctica                                         :universe:ambition:world::meetings:
@@ -1095,10 +1095,10 @@ Wednesday   5 July 2017
   ambition:   In  77 d.:  TODO Visit Mars                                                     :universe:ambition::space:travel:planet:
   test:       Scheduled:  TODO [#C] Get haircut                                                                       :personal:@town:
   ambition:   TODO Practice leaping tall                     !                                           :universe:ambition::personal:
-" "0af641100cfcc5f64d157b26e26fc5b9" "Day-agenda (W27):
+" "29c8faa14ff46b4082d0c83629c2faa2" "Day-agenda (W27):
 Wednesday   5 July 2017
 
- Property: '5' = 'Effort'
+ Property: 'Effort' = '\"5\"'
   test:       18:00...... Scheduled:  TODO Order a pizza                                                                 :food:dinner:
 
  Other items
@@ -1118,6 +1118,99 @@ Wednesday   5 July 2017
   test:       In  27 d.:  TODO [#A] Spaceship lease                                                                  :bills:spaceship:
   test:       Scheduled:  TODO [#B] Fix flux capacitor                                                  :spaceship:shopping:@computer:
   test:       Scheduled:  TODO Shop for groceries                                                                :food:shopping:@town:
+  ideas:      Scheduled:  SOMEDAY Rewrite Emacs in Common Lisp                            :Emacs:elisp:computers:software:programming:
+  test:       Deadline:   CHECK /r/emacs                                                                               :website:Emacs:
+  ambition:   In   5 d.:  TODO [#B] Renew membership in supervillain club                                         :universe:ambition::
+  test:       In  16 d.:  TODO [#B] Internet                                                                                   :bills:
+  ambition:   In  53 d.:  WAITING Visit the moon                                                     :universe:ambition::space:travel:
+  ambition:   In  77 d.:  TODO Visit Mars                                                     :universe:ambition::space:travel:planet:
+  test:       Scheduled:  TODO [#C] Get haircut                                                                       :personal:@town:
+  ambition:   TODO Practice leaping tall                     !                                           :universe:ambition::personal:
+" "e29293019f52072cbdadb86b043e0e2c" "Day-agenda (W27):
+Wednesday   5 July 2017
+
+ Property: 'Effort' = '(lambda (v) (string= v \"5\"))'
+  test:       18:00...... Scheduled:  TODO Order a pizza                                                                 :food:dinner:
+
+ Other items
+  test:        7:02...... Sunrise (12:04 of daylight)
+               8:00...... ----------------
+              10:00...... ----------------
+              12:00...... now - - - - - - - - - - - - - - - - - - - - - - - - -
+              12:00...... ----------------
+              14:00...... ----------------
+              16:00...... ----------------
+              18:00...... ----------------
+  test:       19:07...... Sunset 
+              20:00...... ----------------
+  ambition:   Sched. 1x:  TODO [#A] Skype with president of Antarctica                             :universe:ambition:world::meetings:
+  ambition:   In   2 d.:  TODO [#A] Take over the world                                                     :universe:ambition::world:
+  ambition:   In  10 d.:  TODO [#A] Take over the universe                                                         :universe:ambition:
+  test:       In  27 d.:  TODO [#A] Spaceship lease                                                                  :bills:spaceship:
+  test:       Scheduled:  TODO [#B] Fix flux capacitor                                                  :spaceship:shopping:@computer:
+  test:       Scheduled:  TODO Shop for groceries                                                                :food:shopping:@town:
+  ideas:      Scheduled:  SOMEDAY Rewrite Emacs in Common Lisp                            :Emacs:elisp:computers:software:programming:
+  test:       Deadline:   CHECK /r/emacs                                                                               :website:Emacs:
+  ambition:   In   5 d.:  TODO [#B] Renew membership in supervillain club                                         :universe:ambition::
+  test:       In  16 d.:  TODO [#B] Internet                                                                                   :bills:
+  ambition:   In  53 d.:  WAITING Visit the moon                                                     :universe:ambition::space:travel:
+  ambition:   In  77 d.:  TODO Visit Mars                                                     :universe:ambition::space:travel:planet:
+  test:       Scheduled:  TODO [#C] Get haircut                                                                       :personal:@town:
+  ambition:   TODO Practice leaping tall                     !                                           :universe:ambition::personal:
+" "e782d297fe34c306951019e1ef526cda" "Day-agenda (W27):
+Wednesday   5 July 2017
+
+ Property: 'Effort'
+  test:       18:00...... Scheduled:  TODO Order a pizza                                                                 :food:dinner:
+  test:       Scheduled:  TODO Shop for groceries                                                                :food:shopping:@town:
+
+ Other items
+  test:        7:02...... Sunrise (12:04 of daylight)
+               8:00...... ----------------
+              10:00...... ----------------
+              12:00...... now - - - - - - - - - - - - - - - - - - - - - - - - -
+              12:00...... ----------------
+              14:00...... ----------------
+              16:00...... ----------------
+              18:00...... ----------------
+  test:       19:07...... Sunset 
+              20:00...... ----------------
+  ambition:   Sched. 1x:  TODO [#A] Skype with president of Antarctica                             :universe:ambition:world::meetings:
+  ambition:   In   2 d.:  TODO [#A] Take over the world                                                     :universe:ambition::world:
+  ambition:   In  10 d.:  TODO [#A] Take over the universe                                                         :universe:ambition:
+  test:       In  27 d.:  TODO [#A] Spaceship lease                                                                  :bills:spaceship:
+  test:       Scheduled:  TODO [#B] Fix flux capacitor                                                  :spaceship:shopping:@computer:
+  ideas:      Scheduled:  SOMEDAY Rewrite Emacs in Common Lisp                            :Emacs:elisp:computers:software:programming:
+  test:       Deadline:   CHECK /r/emacs                                                                               :website:Emacs:
+  ambition:   In   5 d.:  TODO [#B] Renew membership in supervillain club                                         :universe:ambition::
+  test:       In  16 d.:  TODO [#B] Internet                                                                                   :bills:
+  ambition:   In  53 d.:  WAITING Visit the moon                                                     :universe:ambition::space:travel:
+  ambition:   In  77 d.:  TODO Visit Mars                                                     :universe:ambition::space:travel:planet:
+  test:       Scheduled:  TODO [#C] Get haircut                                                                       :personal:@town:
+  ambition:   TODO Practice leaping tall                     !                                           :universe:ambition::personal:
+" "31fecc75d5e0a7b47625d709eb31da33" "Day-agenda (W27):
+Wednesday   5 July 2017
+
+ Property: 'Effort'
+  test:       18:00...... Scheduled:  TODO Order a pizza                                                                 :food:dinner:
+  test:       Scheduled:  TODO Shop for groceries                                                                :food:shopping:@town:
+
+ Other items
+  test:        7:02...... Sunrise (12:04 of daylight)
+               8:00...... ----------------
+              10:00...... ----------------
+              12:00...... now - - - - - - - - - - - - - - - - - - - - - - - - -
+              12:00...... ----------------
+              14:00...... ----------------
+              16:00...... ----------------
+              18:00...... ----------------
+  test:       19:07...... Sunset 
+              20:00...... ----------------
+  ambition:   Sched. 1x:  TODO [#A] Skype with president of Antarctica                             :universe:ambition:world::meetings:
+  ambition:   In   2 d.:  TODO [#A] Take over the world                                                     :universe:ambition::world:
+  ambition:   In  10 d.:  TODO [#A] Take over the universe                                                         :universe:ambition:
+  test:       In  27 d.:  TODO [#A] Spaceship lease                                                                  :bills:spaceship:
+  test:       Scheduled:  TODO [#B] Fix flux capacitor                                                  :spaceship:shopping:@computer:
   ideas:      Scheduled:  SOMEDAY Rewrite Emacs in Common Lisp                            :Emacs:elisp:computers:software:programming:
   test:       Deadline:   CHECK /r/emacs                                                                               :website:Emacs:
   ambition:   In   5 d.:  TODO [#B] Renew membership in supervillain club                                         :universe:ambition::
@@ -1770,6 +1863,13 @@ Wednesday   5 July 2017
 " "25b5f6da5442f760584293ee1a07e0e8" "Day-agenda (W27):
 Wednesday   5 July 2017
 
+ Face: default
+  test:       In  27 d.:  TODO [#A] Spaceship lease                                                                  :bills:spaceship:
+  ambition:   In   5 d.:  TODO [#B] Renew membership in supervillain club                                         :universe:ambition::
+  test:       In  16 d.:  TODO [#B] Internet                                                                                   :bills:
+  ambition:   In  53 d.:  WAITING Visit the moon                                                     :universe:ambition::space:travel:
+  ambition:   In  77 d.:  TODO Visit Mars                                                     :universe:ambition::space:travel:planet:
+
  Face: org-agenda-calendar-sexp
   test:        7:02...... Sunrise (12:04 of daylight)
   test:       19:07...... Sunset 
@@ -1788,13 +1888,6 @@ Wednesday   5 July 2017
  Face: org-upcoming-deadline
   ambition:   In   2 d.:  TODO [#A] Take over the world                                                     :universe:ambition::world:
   ambition:   In  10 d.:  TODO [#A] Take over the universe                                                         :universe:ambition:
-
- Face: org-upcoming-distant-deadline
-  test:       In  27 d.:  TODO [#A] Spaceship lease                                                                  :bills:spaceship:
-  ambition:   In   5 d.:  TODO [#B] Renew membership in supervillain club                                         :universe:ambition::
-  test:       In  16 d.:  TODO [#B] Internet                                                                                   :bills:
-  ambition:   In  53 d.:  WAITING Visit the moon                                                     :universe:ambition::space:travel:
-  ambition:   In  77 d.:  TODO Visit Mars                                                     :universe:ambition::space:travel:planet:
 
  Face: org-warning
   test:       Deadline:   CHECK /r/emacs                                                                               :website:Emacs:

--- a/test/test.el
+++ b/test/test.el
@@ -80,7 +80,7 @@
         (unless (> (point) eod)
           (goto-char (match-beginning 0))
           (forward-sexp)
-          (eval-last-sexp nil))))))
+          (ignore-errors (eval-last-sexp nil))))))) ;; to allow (should-error ...)
 
 (defun org-super-agenda--test-ert-def-this-test ()
   (save-excursion
@@ -533,10 +533,31 @@ buffer and do not save the results."
            :groups '((:pred (lambda (item)
                               (s-contains? "moon" item)))))))
 
-(ert-deftest org-super-agenda--test-:property ()
+(ert-deftest org-super-agenda--test-:property-list-val ()
   ;; DONE: Works.
   (should (org-super-agenda--test-run
-           :groups '((:property ("Effort" . "5" ))))))
+           :groups '((:property ("Effort" "5" ))))))
+
+(ert-deftest org-super-agenda--test-:property-list-fun ()
+  ;; DONE: Works.
+  (should (org-super-agenda--test-run
+           :groups '((:property ("Effort" (lambda (v) (string= v "5"))))))))
+
+(ert-deftest org-super-agenda--test-:property-str ()
+  ;; DONE: Works.
+  (should (org-super-agenda--test-run
+           :groups '((:property "Effort")))))
+
+(ert-deftest org-super-agenda--test-:property-list ()
+  ;; DONE: Works.
+  (should (org-super-agenda--test-run
+           :groups '((:property ("Effort"))))))
+
+(ert-deftest org-super-agenda--test-:property-err-check ()
+  ;; DONE: Works.
+  (let ((debug-on-error nil))
+    (should-error (org-super-agenda--test-run
+                   :groups '((:property ("Effort" 'sym-not-allowed-here)))))))
 
 (ert-deftest org-super-agenda--test-:priority ()
   ;; DONE: Works.

--- a/test/test.el
+++ b/test/test.el
@@ -533,6 +533,11 @@ buffer and do not save the results."
            :groups '((:pred (lambda (item)
                               (s-contains? "moon" item)))))))
 
+(ert-deftest org-super-agenda--test-:property ()
+  ;; DONE: Works.
+  (should (org-super-agenda--test-run
+           :groups '((:property ("Effort" . "5" ))))))
+
 (ert-deftest org-super-agenda--test-:priority ()
   ;; DONE: Works.
   (should (org-super-agenda--test-run


### PR DESCRIPTION
This is a continuation and replacement of PR #125 so I won't duplicate the text already there. (I switched from master to a feature branch, and did not find a way to modify the existing PR to reflect this.)

Following up on the good ideas of alphapapa, the following alternations have been made:

- :property now accepts this kind of argument:
   - "string" or ("string")  - selector will match any item with the named property.
   -  ("string" "value")      - selector will match any item with the named property that has the given value.
   -  ("string" (lambda (value) ...)) - selector will match any item with the named property, and for which the function returns true given the item's property value.
- some additional positive ert-tests (should ...)
- a negative ert-test (should-error ...)
- updated result.el (this time I commited it as a whole)
