### PR TITLE
Fix failing automap test

### DIFF
--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -505,7 +505,13 @@ COMPARISON should be a symbol, one of: `past' or `before',
 ;;;;; Effort
 
 (cl-defmacro org-super-agenda--defeffort-group (name docstring &key comparator)
-  "Group items that are COMPARATOR to the given effort."
+  "Define an effort-grouping function.
+
+NAME is a symbol that will be appended to `effort' to construct the group name.
+
+DOCSTRING is a string used for the function's docstring.
+
+COMPARATOR is the binary operator used for the grouping comparison."
   (declare (indent defun))
   `(org-super-agenda--defgroup ,(intern (concat "effort" (symbol-name name)))
      ,(concat docstring "\nArgument is a time-duration string, like \"5\" or \"0:05\" for 5 minutes.")
@@ -714,7 +720,13 @@ e.g. \"A\" or (\"B\" \"C\")."
   :test (cl-member (org-super-agenda--get-priority-cookie item) args :test 'string=))
 
 (cl-defmacro org-super-agenda--defpriority-group (name docstring &key comparator)
-  "Group items that are COMPARATOR than the given priority."
+  "Define a priority-grouping function.
+
+NAME is a symbol that will be appended to `priority' to construct the group name.
+
+DOCSTRING is a string used for the function's docstring.
+
+COMPARATOR is the binary operator used for the grouping comparison."
   (declare (indent defun))
   `(org-super-agenda--defgroup ,(intern (concat "priority" (symbol-name name)))
      ,(concat docstring "\nArgument is a string; it may also be a list of

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -843,7 +843,8 @@ The string should be the priority cookie letter, e.g. \"A\".")
                                                     (header-form 'key) (key-sort-fn #'string<))
   "Define an auto-grouping function.
 
-The function will be named `org-super-agenda--auto-group-NAME'.
+For the function name, NAME will be concatenated to
+`org-super-agenda--auto-group-'.
 
 The docstring will be, \"Divide ALL-ITEMS into groups based on
 DOCSTRING_ENDING.\".

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -342,10 +342,10 @@ with the function, which is used by the dispatcher.
 
 DOCSTRING is a string used for the function's docstring.
 
-:SECTION-NAME is a string or a lisp form that is run once, with
+:SECTION-NAME is a string or a Lisp form that is run once, with
 the variable `items' available.
 
-:TEST is a lisp form that is run for each item, with the variable
+:TEST is a Lisp form that is run for each item, with the variable
 `item' available.  Items passing this test are filtered into a
 separate list.
 

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -514,7 +514,8 @@ DOCSTRING is a string used for the function's docstring.
 COMPARATOR is the binary operator used for the grouping comparison."
   (declare (indent defun))
   `(org-super-agenda--defgroup ,(intern (concat "effort" (symbol-name name)))
-     ,(concat docstring "\nArgument is a time-duration string, like \"5\" or \"0:05\" for 5 minutes.")
+     ,(concat docstring "\nArgument is a time-duration string,
+like \"5\" or \"0:05\" for 5 minutes.")
      :section-name (concat "Effort " ,(symbol-name name) " "
                            (s-join " or " args) " items")
      :let* ((effort-minutes (org-duration-to-minutes (car args))))
@@ -722,11 +723,13 @@ e.g. \"A\" or (\"B\" \"C\")."
 (cl-defmacro org-super-agenda--defpriority-group (name docstring &key comparator)
   "Define a priority-grouping function.
 
-NAME is a symbol appended to `priority' to construct the group name.
+NAME is a symbol appended to `priority' to construct the group
+name.
 
 DOCSTRING is a string used for the function's docstring.
 
-COMPARATOR is the binary operator used for the grouping comparison."
+COMPARATOR is the binary operator used for the grouping
+comparison."
   (declare (indent defun))
   `(org-super-agenda--defgroup ,(intern (concat "priority" (symbol-name name)))
      ,(concat docstring "\nArgument is a string; it may also be a list of

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -505,6 +505,7 @@ COMPARISON should be a symbol, one of: `past' or `before',
 ;;;;; Effort
 
 (cl-defmacro org-super-agenda--defeffort-group (name docstring &key comparator)
+  "Group items that are COMPARATOR to the given effort."
   (declare (indent defun))
   `(org-super-agenda--defgroup ,(intern (concat "effort" (symbol-name name)))
      ,(concat docstring "\nArgument is a time-duration string, like \"5\" or \"0:05\" for 5 minutes.")
@@ -713,6 +714,7 @@ e.g. \"A\" or (\"B\" \"C\")."
   :test (cl-member (org-super-agenda--get-priority-cookie item) args :test 'string=))
 
 (cl-defmacro org-super-agenda--defpriority-group (name docstring &key comparator)
+  "Group items that are COMPARATOR than the given priority."
   (declare (indent defun))
   `(org-super-agenda--defgroup ,(intern (concat "priority" (symbol-name name)))
      ,(concat docstring "\nArgument is a string; it may also be a list of

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -850,7 +850,7 @@ For the function name, NAME will be concatenated to
 The docstring will be, \"Divide ALL-ITEMS into groups based on
 DOCSTRING-ENDING.\".
 
-The selector keyword will be `:auto-NAME'.
+The selector KEYWORD will be `:auto-NAME'.
 
 Items will be grouped by the value of KEY-FORM evaluated for each
 item, with the variable `item' bound to the string from the

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -722,7 +722,7 @@ e.g. \"A\" or (\"B\" \"C\")."
 (cl-defmacro org-super-agenda--defpriority-group (name docstring &key comparator)
   "Define a priority-grouping function.
 
-NAME is a symbol that will be appended to `priority' to construct the group name.
+NAME is a symbol appended to `priority' to construct the group name.
 
 DOCSTRING is a string used for the function's docstring.
 

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -510,9 +510,9 @@ COMPARISON should be a symbol, one of: `past' or `before',
      ,(concat docstring "\nArgument is a time-duration string, like \"5\" or \"0:05\" for 5 minutes.")
      :section-name (concat "Effort " ,(symbol-name name) " "
                            (s-join " or " args) " items")
-     :let* ((effort-minutes (org-duration-string-to-minutes (car args))))
+     :let* ((effort-minutes (org-duration-to-minutes (car args))))
      :test (when-let ((item-effort (org-find-text-property-in-string 'effort item)))
-             (,comparator (org-duration-string-to-minutes item-effort) effort-minutes))))
+             (,comparator (org-duration-to-minutes item-effort) effort-minutes))))
 
 (org-super-agenda--defeffort-group <
   "Group items that are less than (or equal to) the given effort."

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -848,7 +848,7 @@ For the function name, NAME will be concatenated to
 `org-super-agenda--auto-group-'.
 
 The docstring will be, \"Divide ALL-ITEMS into groups based on
-DOCSTRING_ENDING.\".
+DOCSTRING-ENDING.\".
 
 The selector keyword will be `:auto-NAME'.
 

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -845,7 +845,8 @@ The string should be the priority cookie letter, e.g. \"A\".")
 
 The function will be named `org-super-agenda--auto-group-NAME'.
 
-The docstring will be, \"Divide ALL-ITEMS into groups based on DOCSTRING_ENDING.\".
+The docstring will be, \"Divide ALL-ITEMS into groups based on
+DOCSTRING_ENDING.\".
 
 The selector keyword will be `:auto-NAME'.
 

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -507,7 +507,8 @@ COMPARISON should be a symbol, one of: `past' or `before',
 (cl-defmacro org-super-agenda--defeffort-group (name docstring &key comparator)
   "Define an effort-grouping function.
 
-NAME is a symbol that will be appended to `effort' to construct the group name.
+NAME is a symbol that will be appended to `effort' to construct
+the group name.
 
 DOCSTRING is a string used for the function's docstring.
 

--- a/test/results.el
+++ b/test/results.el
@@ -1736,7 +1736,7 @@ Wednesday   5 July 2017
               18:00...... ----------------
   test:       19:07...... Sunset 
               20:00...... ----------------
-" "25b5f6da5442f760584293ee1a07e0e8" "Day-agenda (W27):
+" "org-super-agenda-test--:auto-map" "Day-agenda (W27):
 Wednesday   5 July 2017
 
  Face: org-agenda-calendar-sexp

--- a/test/test.el
+++ b/test/test.el
@@ -218,6 +218,7 @@ where FUNCTION-BODY is a lambda form."
 (cl-defmacro org-super-agenda-test--run
     (&key (body '(org-agenda-list))
           (groups nil groups-set)
+          (overridehashkey nil)
           (span 'day)
           (date org-super-agenda-test-date)
           let*)
@@ -226,7 +227,9 @@ When `org-super-agenda-test-save-results' is non-nil, save the
 new-result to the results file.  When
 `org-super-agenda-test-show-results' is non-nil, show the agenda
 buffer and do not save the results.  Load test results if not
-already loaded."
+already loaded.
+
+Use OVERRIDEHASHKEY to look up the test result, if that is set."
   (declare (debug (form &optional listp sexp sexp stringp)))
   `(progn
      (unless (> (ht-size org-super-agenda-test-results) 0)
@@ -235,6 +238,9 @@ already loaded."
      (org-super-agenda-mode 1)
      (let ((body-groups-hash (secure-hash 'md5 (format "%S" (list ',body ,groups))))
            new-result)
+
+       ;; Use the overridehashkey if it's set.
+       (setq body-groups-hash (if ,overridehashkey ,overridehashkey body-groups-hash))
 
        ;; Redefine functions
        (org-super-agenda-test--with-mock-functions
@@ -677,7 +683,8 @@ already loaded."
 				  (when-let* ((pos (text-property-not-all 0 (length item)
 									  'face nil item)))
                                     (format "Face: %s"
-					    (get-text-property pos 'face item)))))))))
+					    (get-text-property pos 'face item))))))
+	   :overridehashkey "org-super-agenda-test--:auto-map")))
 
 (ert-deftest org-super-agenda-test--:auto-tags ()
   ;; DONE: Works.


### PR DESCRIPTION
This commit builds on PR #139, and so may need to be rebased and re-issued if those commits are squashed.

The only commit that matters in this branch is the last one, 3bc5824.  In summary, this commit lets us refer to test results by human-readable string, rather than a hash, and we can use that human-readable string as the lookup key when running the tests.

I'm not a Lisp programmer, so if there's a better way to write this commit, let me know.  Cheers! z