### PR TITLE
Ensure text heading properties are preserved in `make-agenda-header`

### DIFF
--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -280,8 +280,10 @@ face `org-super-agenda-header' appended, and the text properties
     (_ (let ((separator (cl-etypecase org-super-agenda-header-separator
                           (character (concat (s-repeat (window-width) org-super-agenda-header-separator)
                                              "\n"))
-                          (string org-super-agenda-header-separator))))
+                          (string org-super-agenda-header-separator)))
+             (props (text-properties-at 0 s)))
          (setq s (concat " " s))
+         (set-text-properties 0 (length s) props s)
          (add-face-text-property 0 (length s) 'org-super-agenda-header t s)
          (org-add-props s org-super-agenda-header-properties
            'keymap org-super-agenda-header-map


### PR DESCRIPTION
`make-agenda-header` concats a space " " to incoming header strings.
This change ensures the incoming text properties apply to this space.

This causes `org-agenda-switch-to` (and friends) pass the
`org-get-at-bol` check for `org-marker` when it is present.