### PR TITLE
Filter the :append property from extra faces applied to items.

### DIFF
--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -783,6 +783,7 @@ The string should be the priority cookie letter, e.g. \"A\".")
                  for face = (plist-get filter :face)
                  when face
                  do (let ((append (plist-get face :append)))
+                      (when append (cl-remf face :append))
                       (--each matching
                         (add-face-text-property 0 (length it) face append it)))
 


### PR DESCRIPTION
Getting rid of the `:append` prevents this from happening:

> Invalid face attribute :append t [108 times]

The only way I see to make it faster is to demand that the `:append` should be the first item in the face property, then we could simply use the `cddr` if we find it. Otherwise I see no way to avoid the full iteration.

Depending on where the `:append` appears exactly the filter may or may not return a backwards version of the input, but since it's used for face properties it should not be an issue.