### PR TITLE
Add the :take selector to limit number of entries in a group

### DIFF
--- a/README.org
+++ b/README.org
@@ -183,6 +183,7 @@ Every selector requires an argument, even if it's just ~t~, e.g. ~:anything~, ~:
      -  Note that the ~:not~ group selector /creates/ a group with items it /does not/ match; it can be combined with ~:discard~ to discard items that /don't/ match.  For example, ~(:discard (:not (:priority "A")))~ as the first selector would mean that only priority ~A~ items would appear in the agenda, while ~(:discard (:priority "C"))~ would mean that any priority ~C~ items would not appear in the agenda.
 +  =:order= :: A number setting the order sections will be displayed in the agenda, lowest number first.  Defaults to =0=.
 +  =:order-multi= :: Set the order of multiple groups at once, like ~(:order-multi (2 (groupA) (groupB) ...))~ to set the order of these groups to 2.
++  =:take= :: Take the first N items in GROUP. If N is negative, take the last N items. For example, ~(:take (-3 group))~ will take the last 3 items from the group. The remainder of items are discarded. Note: The order of entries from GROUP is not guaranteed to be preserved, so ~:take~ may not always show expected entries. 
 
 *** Normal selectors
 

--- a/README.org
+++ b/README.org
@@ -183,7 +183,7 @@ Every selector requires an argument, even if it's just ~t~, e.g. ~:anything~, ~:
      -  Note that the ~:not~ group selector /creates/ a group with items it /does not/ match; it can be combined with ~:discard~ to discard items that /don't/ match.  For example, ~(:discard (:not (:priority "A")))~ as the first selector would mean that only priority ~A~ items would appear in the agenda, while ~(:discard (:priority "C"))~ would mean that any priority ~C~ items would not appear in the agenda.
 +  =:order= :: A number setting the order sections will be displayed in the agenda, lowest number first.  Defaults to =0=.
 +  =:order-multi= :: Set the order of multiple groups at once, like ~(:order-multi (2 (groupA) (groupB) ...))~ to set the order of these groups to 2.
-+  =:take= :: Take the first N items in GROUP. If N is negative, take the last N items. For example, ~(:take (-3 group))~ will take the last 3 items from the group. The remainder of items are discarded. Note: The order of entries from GROUP is not guaranteed to be preserved, so ~:take~ may not always show expected entries. 
++  =:take= :: Take the first N items in GROUP.  If N is negative, take the last N items.  For example, ~(:take (-3 group))~ will take the last 3 items from the group.  The remainder of items are discarded.  Note: The order of entries from GROUP is not guaranteed to be preserved, so ~:take~ may not always show expected entries.
 
 *** Normal selectors
 

--- a/README.org
+++ b/README.org
@@ -242,6 +242,7 @@ As explained in the usage instructions and shown in the example, items are colle
 
 *Added*
 +  Selector ~:property~, which groups items with a property, optionally also matching a value or predicate.  (Thanks to [[https://github.com/weipe][Per Weijnitz]].)
++  Special selector ~:take~, which limits the number of items displayed in a group.  (Thanks to [[https://github.com/pkazmier][Pete Kazmier]].)
 
 ** 1.2
 

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -1124,9 +1124,9 @@ see."
 
 (cl-defun org-super-agenda--group-dispatch-take (items (n &rest group))
   "Take N ITEMS that match selectors in GROUP.
-If N is positive, take the first N items, otherwise take the last N items. Note:
-the ordering of entries is not guarateed to be preserved, so this may not always
-show the expected results."
+If N is positive, take the first N items, otherwise take the last N items.
+Note: the ordering of entries is not guaranteed to be preserved, so this may
+not always show the expected results."
   (-let* (((name non-matching matching) (org-super-agenda--group-dispatch items group))
           (take-fn (if (cl-minusp n) #'-take-last #'-take))
           (placement (if (cl-minusp n) "Last" "First"))

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -1128,8 +1128,8 @@ If N is positive, take the first N items, otherwise take the last N items. Note:
 the ordering of entries is not guarateed to be preserved, so this may not always
 show the expected results."
   (-let* (((name non-matching matching) (org-super-agenda--group-dispatch items group))
-          (take-fn (if (< n 0) #'-take-last #'-take))
-          (placement (if (< n 0) "Last" "First"))
+          (take-fn (if (cl-minusp n) #'-take-last #'-take))
+          (placement (if (cl-minusp n) "Last" "First"))
           (name (format "%s %d %s" placement (abs n) name)))
     (list name non-matching (funcall take-fn (abs n) matching))))
 (setq org-super-agenda-group-types (plist-put org-super-agenda-group-types

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -1122,6 +1122,19 @@ see."
 (setq org-super-agenda-group-types (plist-put org-super-agenda-group-types
                                               :not 'org-super-agenda--group-dispatch-not))
 
+(cl-defun org-super-agenda--group-dispatch-take (items (n &rest group))
+  "Take N ITEMS that match selectors in GROUP.
+If N is positive, take the first N items, otherwise take the last N items. Note:
+the ordering of entries is not guarateed to be preserved, so this may not always
+show the expected results."
+  (-let* (((name non-matching matching) (org-super-agenda--group-dispatch items group))
+          (take-fn (if (< n 0) #'-take-last #'-take))
+          (placement (if (< n 0) "Last" "First"))
+          (name (format "%s %d %s" placement (abs n) name)))
+    (list name non-matching (funcall take-fn (abs n) matching))))
+(setq org-super-agenda-group-types (plist-put org-super-agenda-group-types
+                                              :take 'org-super-agenda--group-dispatch-take))
+
 (defun org-super-agenda--group-dispatch-discard (items group)
   "Discard ITEMS that match GROUP.
 Any groups processed after this will not see these items."

--- a/org-super-agenda.info
+++ b/org-super-agenda.info
@@ -382,6 +382,12 @@ Every selector requires an argument, even if it’s just ‘t’, e.g.
 ‘:order-multi’
      Set the order of multiple groups at once, like ‘(:order-multi (2
      (groupA) (groupB) ...))’ to set the order of these groups to 2.
+‘:take’
+     Take the first N items in GROUP. If N is negative, take the last N
+     items.  For example, ‘(:take (-3 group))’ will take the last 3
+     items from the group.  The remainder of items are discarded.  Note:
+     The order of entries from GROUP is not guaranteed to be preserved,
+     so ‘:take’ may not always show expected entries.
 
 
 File: README.info,  Node: Normal selectors,  Prev: Special selectors,  Up: Group selectors
@@ -568,6 +574,9 @@ File: README.info,  Node: 13-pre,  Next: 12,  Up: Changelog
    • Selector ‘:property’, which groups items with a property,
      optionally also matching a value or predicate.  (Thanks to Per
      Weijnitz (https://github.com/weipe).)
+   • Special selector ‘:take’, which limits the number of items
+     displayed in a group.  (Thanks to Pete Kazmier
+     (https://github.com/pkazmier).)
 
 
 File: README.info,  Node: 12,  Next: 111,  Prev: 13-pre,  Up: Changelog
@@ -782,24 +791,24 @@ Node: Examples4485
 Node: Group selectors7970
 Node: Keywords8932
 Node: Special selectors9673
-Node: Normal selectors13532
-Node: Tips18394
-Node: FAQ19245
-Node: Why are some items not displayed even though I used group selectors for them?19495
-Node: Why did a group disappear when I moved it to the end of the list?20366
-Node: Changelog20941
-Node: 13-pre21176
-Node: 1221453
-Node: 11124037
-Node: 1124206
-Node: 10325778
-Node: 10225989
-Node: 10126123
-Node: 10026461
-Node: Development26566
-Node: Bugs26968
-Node: Tests27621
-Node: Credits27940
+Node: Normal selectors13891
+Node: Tips18753
+Node: FAQ19604
+Node: Why are some items not displayed even though I used group selectors for them?19854
+Node: Why did a group disappear when I moved it to the end of the list?20725
+Node: Changelog21300
+Node: 13-pre21535
+Node: 1221971
+Node: 11124555
+Node: 1124724
+Node: 10326296
+Node: 10226507
+Node: 10126641
+Node: 10026979
+Node: Development27084
+Node: Bugs27486
+Node: Tests28139
+Node: Credits28458
 
 End Tag Table
 


### PR DESCRIPTION
Here is the PR for #172. I changed the name of the selector from `:head` to `:take`. In addition, I updated `README.org` to document the new selector. As a very infrequent visitor to Elisp-land, I was unable to understand your test framework and could not figure out how to add a test case.