### PR TITLE
Removed check for 'dotime in time-grid.

### DIFF
--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -450,13 +450,7 @@ agenda time-grid. "
               ;; This property is a string; if empty, it doesn't match
               (not (string-empty-p it)))
             ;; This property is nil if it doesn't match
-            (org-find-text-property-in-string 'time-of-day item)
-            (--when-let (org-find-text-property-in-string 'dotime item)
-              ;; For this to match, the 'dotime property must be set, and
-              ;; it must not be equal to 'time.  If it is not set, or if
-              ;; it is set and is equal to 'time, the item is not part of
-              ;; the time-grid.  Yes, this is confusing.  :)
-              (not (eql it 'time)))))
+            (org-find-text-property-in-string 'time-of-day item)))
 
 (org-super-agenda--defgroup deadline
   "Group items that have a deadline.


### PR DESCRIPTION
Possible fix for #212 

Might be a naive solution, but I'm not sure what the check for `'dotime` is supposed to account for. This solved the issue for my configuration and use-case. I'm not sure how your testing framework works in order to see if I've messed anything else up that you've already thought of though.