### PR TITLE
Add custom variable for the mode toggle message

### DIFF
--- a/README.org
+++ b/README.org
@@ -239,7 +239,8 @@ As explained in the usage instructions and shown in the example, items are colle
 
 ** 1.4-pre
 
-Nothing new yet.
+*Additions*
++ Option ~org-super-agenda-show-message~ allows disabling of the message shown when the mode is enabled.  (Thanks to [[https://github.com/hpfr][Liam Hupfer]].)
 
 ** 1.3
 

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -164,6 +164,10 @@ origin (e.g. Org QL's link-handling code).")
   :group 'org
   :link '(url-link "http://github.com/alphapapa/org-super-agenda"))
 
+(defcustom org-super-agenda-show-message t
+  "Show a message when `org-super-agenda-mode' is toggled."
+  :type 'boolean)
+
 (defcustom org-super-agenda-groups nil
   "List of groups to apply to agenda views.
 See readme for information."
@@ -369,9 +373,10 @@ With prefix argument ARG, turn on if positive, otherwise off."
         (add-to-list 'org-agenda-local-vars 'org-super-agenda-groups)
       (setq org-agenda-local-vars (remove 'org-super-agenda-groups org-agenda-local-vars)))
     ;; Display message
-    (message (if org-super-agenda-mode
-                 "org-super-agenda-mode enabled."
-               "org-super-agenda-mode disabled."))))
+    (when org-super-agenda-show-message
+      (message (if org-super-agenda-mode
+                   "org-super-agenda-mode enabled."
+                 "org-super-agenda-mode disabled.")))))
 
 ;;;; Group selectors
 

--- a/org-super-agenda.info
+++ b/org-super-agenda.info
@@ -563,7 +563,10 @@ File: README.info,  Node: 14-pre,  Next: 13,  Up: Changelog
 7.1 1.4-pre
 ===========
 
-Nothing new yet.
+*Additions*
+   • Option ‘org-super-agenda-show-message’ allows disabling of the
+     message shown when the mode is enabled.  (Thanks to Liam Hupfer
+     (https://github.com/hpfr).)
 
 
 File: README.info,  Node: 13,  Next: 12,  Prev: 14-pre,  Up: Changelog
@@ -822,18 +825,18 @@ Node: Why are some items not displayed even though I used group selectors for th
 Node: Why did a group disappear when I moved it to the end of the list?20892
 Node: Changelog21473
 Node: 14-pre21711
-Node: 1321817
-Node: 1223380
-Node: 11126050
-Node: 1126225
-Node: 10327809
-Node: 10228020
-Node: 10128154
-Node: 10028492
-Node: Development28597
-Node: Bugs28999
-Node: Tests29693
-Node: Credits30030
+Node: 1321988
+Node: 1223551
+Node: 11126221
+Node: 1126396
+Node: 10327980
+Node: 10228191
+Node: 10128325
+Node: 10028663
+Node: Development28768
+Node: Bugs29170
+Node: Tests29864
+Node: Credits30201
 
 End Tag Table
 


### PR DESCRIPTION
Re: #131. I see other modes issue enable/disable messages, but I think they use whatever magic is part of `define-minor-mode`, which doesn't nag me on startup 😉.

Thanks for being open to this, and for your work! Big fan of this package.

To reduce the check for its existence, I could autoload the new variable.