### PR TITLE
Ensure buffer exists before selecting its marker in org-super-agenda--when-with-marker-buffer

### DIFF
--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -235,7 +235,7 @@ considerable, depending on the number of items."
   (declare (indent defun) (debug (form body)))
   (org-with-gensyms (marker)
     `(let ((,marker ,form))
-       (when (markerp ,marker)
+       (when (and (markerp ,marker) (marker-buffer ,marker))
          (with-current-buffer (marker-buffer ,marker)
            (save-excursion
              (goto-char ,marker)


### PR DESCRIPTION
Hello,

when using the diary, you don't necessarily have an actual buffer which causes `org-super-agenda` to crash at the line following line:

https://github.com/alphapapa/org-super-agenda/blob/3108bc3f725818f0e868520d2c243abe9acbef4e/org-super-agenda.el#L239

I just did a small patch to ensure that the marker refers to an actual buffer before moving on.