### PR TITLE
Change default value of `org-super-agenda-header-properties` (Fix #236)

### DIFF
--- a/README.org
+++ b/README.org
@@ -249,6 +249,7 @@ As explained in the usage instructions and shown in the example, items are colle
 
 *Fixes*
 + Widen buffers when collecting parent headers. ([[https://github.com/alphapapa/org-super-agenda/issues/231][#231]].  Thanks to [[https://github.com/haji-ali][Abdul-Lateef Haji-Ali]] for reporting.)
++ Showing names of empty sections.  ([[https://github.com/alphapapa/org-super-agenda/issues/236][#236]].  Thanks to [[https://github.com/PaddyPatPat][Patrick Duncan]] and [[https://github.com/cslux][Christian Schwarzgruber]].)
 
 ** 1.2
 

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -210,8 +210,7 @@ See `format-time-string'."
   :type 'string)
 
 (defcustom org-super-agenda-header-properties
-  '(face org-super-agenda-header
-         org-agenda-structural-header t)
+  '(org-agenda-structural-header t)
   "Text properties added to group headers."
   :type 'plist)
 
@@ -310,6 +309,7 @@ of `org-super-agenda-header-map', which see."
          (set-text-properties 0 (length header) properties header)
          (add-face-text-property 0 (length header) 'org-super-agenda-header t header)
          (org-add-props header org-super-agenda-header-properties
+           'org-super-agenda-header t
            'keymap org-super-agenda-header-map
            ;; NOTE: According to the manual, only `keymap' should be necessary, but in my
            ;; testing, it only takes effect in Agenda buffers when `local-map' is set, so

--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -307,8 +307,8 @@ of `org-super-agenda-header-map', which see."
                                     "\n"))
                  (string org-super-agenda-header-separator))))
          (set-text-properties 0 (length header) properties header)
-         (add-face-text-property 0 (length header) 'org-super-agenda-header t header)
          (org-add-props header org-super-agenda-header-properties
+           'face 'org-super-agenda-header
            'org-super-agenda-header t
            'keymap org-super-agenda-header-map
            ;; NOTE: According to the manual, only `keymap' should be necessary, but in my

--- a/org-super-agenda.info
+++ b/org-super-agenda.info
@@ -585,6 +585,10 @@ File: README.info,  Node: 13-pre,  Next: 12,  Up: Changelog
      (https://github.com/alphapapa/org-super-agenda/issues/231).  Thanks
      to Abdul-Lateef Haji-Ali (https://github.com/haji-ali) for
      reporting.)
+   • Showing names of empty sections.  (#236
+     (https://github.com/alphapapa/org-super-agenda/issues/236).  Thanks
+     to Patrick Duncan (https://github.com/PaddyPatPat) and Christian
+     Schwarzgruber (https://github.com/cslux).)
 
 
 File: README.info,  Node: 12,  Next: 111,  Prev: 13-pre,  Up: Changelog
@@ -808,17 +812,17 @@ Node: Why are some items not displayed even though I used group selectors for th
 Node: Why did a group disappear when I moved it to the end of the list?20881
 Node: Changelog21462
 Node: 13-pre21689
-Node: 1223007
-Node: 11125681
-Node: 1125856
-Node: 10327440
-Node: 10227651
-Node: 10127785
-Node: 10028123
-Node: Development28228
-Node: Bugs28630
-Node: Tests29324
-Node: Credits29661
+Node: 1223245
+Node: 11125919
+Node: 1126094
+Node: 10327678
+Node: 10227889
+Node: 10128023
+Node: 10028361
+Node: Development28466
+Node: Bugs28868
+Node: Tests29562
+Node: Credits29899
 
 End Tag Table
 


### PR DESCRIPTION
This should fix it. 

My setup.
``` emacs-lisp
(use-package org-super-agenda
    :defer nil
    :init
    (defun org-super-agenda-toggle ()
      "Toggle `org-super-agenda-mode' and refresh `org-agenda' buffers."
      (interactive)
      (org-super-agenda-mode (if org-super-agenda-mode -1 1))
      (org-agenda-redo-all t))
    :config
    (setq org-super-agenda-hide-empty-groups t
          org-super-agenda-groups
          '((:name "Daily Note" :tag "NOTE" :face)
            (:log t)
            (:time-grid t)
            (:name "Important" :priority "A" :face)
            (:order-multi (100
                           (:name "Someday/Maybe" :tag "SM")
                           (:name "Anniversaries" :category "Anniversa.")))
            (:order-multi (2
                           (:name "Projects" :tag "PROJECT")
                           (:name "Computer" :category "Computer")
                           (:name "Home" :category "Home")
                           (:name "Errand" :category "Errand")
                           (:name "Talk" :tag "TALK")
                           (:name "Read and Learn" :category "Study")
                           (:name "Miscellaneous" :category "Misc")
                           (:name "Health" :category "Health")
                           (:name "Phone" :tag "PHONE")))
            (:name "Waiting" :todo "WAITING" :order 8)))
    (org-super-agenda-mode t))
```
