### PR TITLE
Fix: resolve invalid `group-dispatch-take` `group` parameter definition

### DIFF
--- a/org-super-agenda.el
+++ b/org-super-agenda.el
@@ -1162,7 +1162,7 @@ see."
 (setq org-super-agenda-group-types (plist-put org-super-agenda-group-types
                                               :not 'org-super-agenda--group-dispatch-not))
 
-(cl-defun org-super-agenda--group-dispatch-take (items (n &rest group))
+(cl-defun org-super-agenda--group-dispatch-take (items (n group))
   "Take N ITEMS that match selectors in GROUP.
 If N is positive, take the first N items, otherwise take the last N items.
 Note: the ordering of entries is not guaranteed to be preserved, so this may


### PR DESCRIPTION
Fixes https://github.com/alphapapa/org-super-agenda/issues/216

Previously, using `:take` was throwing "Invalid org-super-agenda-groups-selector" errors when used with valid syntax. This fixes that so `:take` works as intended.

The cause/solution is described by @cashpw in the linked issue: 

> I think it's the &rest that's causing it. The group variable appears to be wrapped by an extra set of parenthesis in my debug window (eg: ((:tag "concept")) rather than (:tag "concept")). I suspect &rest is adding this to make group into a list.

------

I've been using this change locally for a few months successfully, but have not done any more rigorous testing.

Just wanted to make a PR to summarize the fix from that issue and make it easy to roll out if this is indeed the correct change to make; feel free to change/remove/supersede this PR as you see fit!