### PR TITLE
Enhance README: Shields to capture the attention of potential contributors

### DIFF
--- a/README.org
+++ b/README.org
@@ -337,6 +337,8 @@ First tagged version.
 :TOC:      ignore
 :END:
 
+[![GitHub repo Good Issues for newbies](https://img.shields.io/github/issues/alphapapa/org-super-agenda/good%20first%20issue?style=flat&logo=github&logoColor=green&label=Good%20First%20issues)](https://github.com/alphapapa/org-super-agenda/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) [![GitHub Help Wanted issues](https://img.shields.io/github/issues/alphapapa/org-super-agenda/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20issues)](https://github.com/alphapapa/org-super-agenda/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) [![GitHub Help Wanted PRs](https://img.shields.io/github/issues-pr/alphapapa/org-super-agenda/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20PRs)](https://github.com/alphapapa/org-super-agenda/pulls?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) [![GitHub repo Issues](https://img.shields.io/github/issues/alphapapa/org-super-agenda?style=flat&logo=github&logoColor=red&label=Issues)](https://github.com/alphapapa/org-super-agenda/issues?q=is%3Aopen)
+
 Contributions and feedback are welcome.
 
 If you find this useful, I'd appreciate if you would share a screenshot or two of your agenda views using it (minus any private data, of course).  I'd like to get ideas for how to better organize my agenda.  :)


### PR DESCRIPTION
I noticed you have opened issues labeled `help wanted`. I recommend enhancing the README to make the call for new contributors more prominent.

### Changes Made:

1. **Shields:** Added Shields.io badges at the top of the README

[![GitHub repo Good Issues for newbies](https://img.shields.io/github/issues/alphapapa/org-super-agenda/good%20first%20issue?style=flat&logo=github&logoColor=green&label=Good%20First%20issues)](https://github.com/alphapapa/org-super-agenda/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) [![GitHub Help Wanted issues](https://img.shields.io/github/issues/alphapapa/org-super-agenda/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20issues)](https://github.com/alphapapa/org-super-agenda/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) [![GitHub Help Wanted PRs](https://img.shields.io/github/issues-pr/alphapapa/org-super-agenda/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20PRs)](https://github.com/alphapapa/org-super-agenda/pulls?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) [![GitHub repo Issues](https://img.shields.io/github/issues/alphapapa/org-super-agenda?style=flat&logo=github&logoColor=red&label=Issues)](https://github.com/alphapapa/org-super-agenda/issues?q=is%3Aopen)

```markdown
[![GitHub repo Good Issues for newbies](https://img.shields.io/github/issues/alphapapa/org-super-agenda/good%20first%20issue?style=flat&logo=github&logoColor=green&label=Good%20First%20issues)](https://github.com/alphapapa/org-super-agenda/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) [![GitHub Help Wanted issues](https://img.shields.io/github/issues/alphapapa/org-super-agenda/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20issues)](https://github.com/alphapapa/org-super-agenda/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) [![GitHub Help Wanted PRs](https://img.shields.io/github/issues-pr/alphapapa/org-super-agenda/help%20wanted?style=flat&logo=github&logoColor=b545d1&label=%22Help%20Wanted%22%20PRs)](https://github.com/alphapapa/org-super-agenda/pulls?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) [![GitHub repo Issues](https://img.shields.io/github/issues/alphapapa/org-super-agenda?style=flat&logo=github&logoColor=red&label=Issues)](https://github.com/alphapapa/org-super-agenda/issues?q=is%3Aopen)
```

### Why This Matters:

- **Attract New Contributors:** Considering there is a number of opened issues labeled 'Help Wanted' - a welcoming and appealing README is one of the most efficient ways to attract new contributors

### Additional Resources:

For more insights into building a strong open-source community, check out the [Building Community guide](https://opensource.guide/building-community/). 

🚀 **Thank you for considering this pull request!** 🚀